### PR TITLE
Feature/set up middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.2](https://github.com/Howard86/next-api-handler/compare/v0.0.1...v0.0.2) (2021-10-17)
+
+
+### Features
+
+* **middleware:** add use method to inject middleware to req ([0b4a11e](https://github.com/Howard86/next-api-handler/commit/0b4a11eba7748d2a0730cb8c1b5830b5165113a9))
+
+
+### Bug Fixes
+
+* **config:** fix ava unit test config with serial ([7c8c59f](https://github.com/Howard86/next-api-handler/commit/7c8c59ffc6f0bcb84bd48d9665bbc73c16dddadb))
+
 ### 0.0.1 (2021-10-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-api-handler",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "lightweight nextjs api handler wrapper, portable & configurable for serverless environment",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/router.spec.ts
+++ b/src/lib/router.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava';
 import type { NextApiResponse } from 'next';
-import sinon from 'sinon';
+import sinon, { SinonSpy } from 'sinon';
 
 import {
   ErrorApiResponse,
@@ -30,12 +30,14 @@ const res = {
   },
 } as unknown as NextApiResponse;
 
-const spiedJson = sinon.spy(res, 'json');
-const spiedStatus = sinon.spy(res, 'status');
+let spiedJson: SinonSpy<[data: unknown], void>;
+let spiedStatus: SinonSpy<[statusCode: number], NextApiResponse>;
 
 let router: RouterBuilder;
 
 test.beforeEach(() => {
+  spiedJson = sinon.spy(res, 'json');
+  spiedStatus = sinon.spy(res, 'status');
   router = new RouterBuilder();
 });
 
@@ -44,7 +46,7 @@ test.afterEach(() => {
   spiedStatus.restore();
 });
 
-test('should return 405 for all empty routes', async (t) => {
+test.serial('should return 405 for all empty routes', async (t) => {
   const handler = router.build();
 
   await Promise.all(
@@ -63,28 +65,31 @@ test('should return 405 for all empty routes', async (t) => {
   );
 });
 
-test('should return value controlled by predefined handler', async (t) => {
-  await Promise.all(
-    ROUTING_METHODS.map(async (method) => {
-      const TEXT = `${method.toUpperCase()}_API_RESPONSE`;
-      router[method]((_req) => TEXT);
-      const handler = router.build();
-      await handler(
-        { method: method.toUpperCase() } as NextApiRequestWithMiddleware,
-        res
-      );
-      t.true(spiedStatus.calledWith(200));
-      t.true(
-        spiedJson.calledWith({
-          success: true,
-          data: TEXT,
-        } as SuccessApiResponse<string>)
-      );
-    })
-  );
-});
+test.serial(
+  'should return value controlled by predefined handler',
+  async (t) => {
+    await Promise.all(
+      ROUTING_METHODS.map(async (method) => {
+        const TEXT = `${method.toUpperCase()}_API_RESPONSE`;
+        router[method]((_req) => TEXT);
+        const handler = router.build();
+        await handler(
+          { method: method.toUpperCase() } as NextApiRequestWithMiddleware,
+          res
+        );
+        t.true(spiedStatus.calledWith(200));
+        t.true(
+          spiedJson.calledWith({
+            success: true,
+            data: TEXT,
+          } as SuccessApiResponse<string>)
+        );
+      })
+    );
+  }
+);
 
-test('should handle errors', async (t) => {
+test.serial('should handle errors', async (t) => {
   await Promise.all(
     ROUTING_METHODS.map(async (method) => {
       const error = new Error(`${method.toUpperCase()}_API_ERROR`);
@@ -107,7 +112,7 @@ test('should handle errors', async (t) => {
   );
 });
 
-test('should handle asynchronous request', async (t) => {
+test.serial('should handle asynchronous request', async (t) => {
   await Promise.all(
     ROUTING_METHODS.map(async (method) => {
       const TEXT = `${method.toUpperCase()}_API_RESPONSE`;
@@ -128,26 +133,29 @@ test('should handle asynchronous request', async (t) => {
   );
 });
 
-test('should handle errors thrown by asynchronous request', async (t) => {
-  await Promise.all(
-    ROUTING_METHODS.map(async (method) => {
-      const error = new Error(`${method.toUpperCase()}_API_ERROR`);
-      router[method]((_req) => Promise.reject(error));
-      const handler = router.build();
-      await handler(
-        { method: method.toUpperCase() } as NextApiRequestWithMiddleware,
-        res
-      );
-      t.true(spiedStatus.calledWith(500));
-      t.true(
-        spiedJson.calledWith({
-          success: false,
-          message: error.message,
-        } as ErrorApiResponse)
-      );
-    })
-  );
-});
+test.serial(
+  'should handle errors thrown by asynchronous request',
+  async (t) => {
+    await Promise.all(
+      ROUTING_METHODS.map(async (method) => {
+        const error = new Error(`${method.toUpperCase()}_API_ERROR`);
+        router[method]((_req) => Promise.reject(error));
+        const handler = router.build();
+        await handler(
+          { method: method.toUpperCase() } as NextApiRequestWithMiddleware,
+          res
+        );
+        t.true(spiedStatus.calledWith(500));
+        t.true(
+          spiedJson.calledWith({
+            success: false,
+            message: error.message,
+          } as ErrorApiResponse)
+        );
+      })
+    );
+  }
+);
 
 type FakeCookie = {
   testCookie: string;
@@ -161,52 +169,55 @@ type FakeUser = {
   };
 };
 
-test('should accept middleware and receive values from request', async (t) => {
-  router.get((req) => req.middleware);
-  const handler = router.build();
+test.serial(
+  'should accept middleware and receive values from request',
+  async (t) => {
+    router.get((req) => req.middleware);
+    const handler = router.build();
 
-  const cookieMiddleware = (
-    _req: NextApiRequestWithMiddleware
-  ): FakeCookie => ({
-    testCookie: 'TEST_COOKIE',
-  });
-  router.use<FakeCookie>(cookieMiddleware);
+    const cookieMiddleware = (
+      _req: NextApiRequestWithMiddleware
+    ): FakeCookie => ({
+      testCookie: 'TEST_COOKIE',
+    });
+    router.use<FakeCookie>(cookieMiddleware);
 
-  await handler({ method: 'GET' } as NextApiRequestWithMiddleware, res);
-  t.true(spiedStatus.calledWith(200));
-  t.true(
-    spiedJson.calledWith({
-      success: true,
-      data: {
-        testCookie: 'TEST_COOKIE',
-      },
-    })
-  );
-
-  const userMiddleware = (req: NextApiRequestWithMiddleware): FakeUser => ({
-    user: {
-      id: '1',
-      name: 'TEST_USER',
-      testCookie: req.middleware.testCookie as string,
-    },
-  });
-
-  router.use<FakeUser>(userMiddleware);
-
-  await handler({ method: 'GET' } as NextApiRequestWithMiddleware, res);
-
-  t.true(spiedStatus.calledWith(200));
-  t.true(
-    spiedJson.calledWith({
-      success: true,
-      data: {
-        testCookie: 'TEST_COOKIE',
-        user: {
-          id: '1',
-          name: 'TEST_USER',
+    await handler({ method: 'GET' } as NextApiRequestWithMiddleware, res);
+    t.true(spiedStatus.calledWith(200));
+    t.true(
+      spiedJson.calledWith({
+        success: true,
+        data: {
           testCookie: 'TEST_COOKIE',
         },
+      })
+    );
+
+    const userMiddleware = (req: NextApiRequestWithMiddleware): FakeUser => ({
+      user: {
+        id: '1',
+        name: 'TEST_USER',
+        testCookie: req.middleware.testCookie as string,
       },
-    })
-  );
-});
+    });
+
+    router.use<FakeUser>(userMiddleware);
+
+    await handler({ method: 'GET' } as NextApiRequestWithMiddleware, res);
+
+    t.true(spiedStatus.calledWith(200));
+    t.true(
+      spiedJson.calledWith({
+        success: true,
+        data: {
+          testCookie: 'TEST_COOKIE',
+          user: {
+            id: '1',
+            name: 'TEST_USER',
+            testCookie: 'TEST_COOKIE',
+          },
+        },
+      })
+    );
+  }
+);

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -9,19 +9,25 @@ export type RouterHandler<T = unknown> = (
 ) => RouterBuilder;
 
 /**
- *  a standard next.js api handler,
- *  see [official doc](https://nextjs.org/docs/api-routes/introduction) for more details
+ *  a sync/async function that takes next.js request and optional next.js response
  */
 export type NextApiHandler<T = unknown> = (
   req: NextApiRequestWithMiddleware,
   res?: NextApiResponse
 ) => T | Promise<T>;
 
+/**
+ *  a next.js api request with injected req.middleware
+ */
 export interface NextApiRequestWithMiddleware<T = unknown>
   extends NextApiRequest {
   middleware: Record<string, T>;
 }
 
+/**
+ *  a standard next.js api handler but with req.middleware available
+ *  see [official doc](https://nextjs.org/docs/api-routes/introduction) for more details
+ */
 export type NextApiHandlerWithMiddleware<T = unknown, M = unknown> = (
   req: NextApiRequestWithMiddleware<M>,
   res: NextApiResponse<T>


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature: add `use` & `inject` methods to add middleware **before** handling the request, these middleware will inject values in `req.middleware[key]` for consistency

- **What is the current behavior?** (You can also link to an open issue here)

Currently we are not able to share logic before handling a request

- **What is the new behavior (if this is a feature change)?**

Now we can create middleware that run before handling a request

- **Other information**:

`use` is following `express.js`  API that can pick up previous middleware value, while `inject` is a custom api that runs first & in parallel in regardless of previous request
