### PR TITLE
Bugfix/fix-middleware-type-declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.3](https://github.com/Howard86/next-api-handler/compare/v0.0.2...v0.0.3) (2021-10-17)
+
+
+### Bug Fixes
+
+* **middleware:** update middle type declaration ([2c65ada](https://github.com/Howard86/next-api-handler/commit/2c65adade6ca42396afad821a3a5ddaf30fbc33d))
+
 ### [0.0.2](https://github.com/Howard86/next-api-handler/compare/v0.0.1...v0.0.2) (2021-10-17)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-api-handler",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "lightweight nextjs api handler wrapper, portable & configurable for serverless environment",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -19,16 +19,19 @@ export type NextApiHandler<T = unknown> = (
 /**
  *  a next.js api request with injected req.middleware
  */
-export interface NextApiRequestWithMiddleware<T = unknown>
+export interface NextApiRequestWithMiddleware<T = Record<string, unknown>>
   extends NextApiRequest {
-  middleware: Record<string, T>;
+  middleware: T;
 }
 
 /**
  *  a standard next.js api handler but with req.middleware available
  *  see [official doc](https://nextjs.org/docs/api-routes/introduction) for more details
  */
-export type NextApiHandlerWithMiddleware<T = unknown, M = unknown> = (
+export type NextApiHandlerWithMiddleware<
+  T = unknown,
+  M = Record<string, unknown>
+> = (
   req: NextApiRequestWithMiddleware<M>,
   res: NextApiResponse<T>
 ) => void | Promise<void>;

--- a/src/lib/router.ts
+++ b/src/lib/router.ts
@@ -1,25 +1,22 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
- *  public builder method of RouterBuilder that accepts next.js handler
- *  and return RouterBuilder itself
+ *  an utility type to shorten writing Record<string, T = unknown>
  */
-export type RouterHandler<T = unknown> = (
-  handler: NextApiHandler<T>
-) => RouterBuilder;
+export type TypedObject<T = unknown> = Record<string, T>;
 
 /**
  *  a sync/async function that takes next.js request and optional next.js response
  */
-export type NextApiHandler<T = unknown> = (
-  req: NextApiRequestWithMiddleware,
+export type NextApiHandler<T = unknown, M extends TypedObject = TypedObject> = (
+  req: NextApiRequestWithMiddleware<M>,
   res?: NextApiResponse
 ) => T | Promise<T>;
 
 /**
  *  a next.js api request with injected req.middleware
  */
-export interface NextApiRequestWithMiddleware<T = Record<string, unknown>>
+export interface NextApiRequestWithMiddleware<T = TypedObject>
   extends NextApiRequest {
   middleware: T;
 }
@@ -30,7 +27,7 @@ export interface NextApiRequestWithMiddleware<T = Record<string, unknown>>
  */
 export type NextApiHandlerWithMiddleware<
   T = unknown,
-  M = Record<string, unknown>
+  M extends TypedObject = TypedObject
 > = (
   req: NextApiRequestWithMiddleware<M>,
   res: NextApiResponse<T>
@@ -79,56 +76,73 @@ export type ErrorApiResponse = { success: false; message: string };
  * @returns a builder that can build a next.js api handler.
  */
 export class RouterBuilder {
-  private readonly route: Record<string, NextApiHandler> = {};
-  private readonly middlewareList: NextApiHandler<Record<string, unknown>>[] =
-    [];
-  private readonly middlewareQueue: NextApiHandler<Record<string, unknown>>[] =
-    [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private readonly route: Record<string, NextApiHandler<unknown, any>> = {};
+  private readonly middlewareList: NextApiHandler<TypedObject>[] = [];
+  private readonly middlewareQueue: NextApiHandler<TypedObject>[] = [];
 
-  get<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  get<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('GET', handler);
   }
 
-  head<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  head<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('HEAD', handler);
   }
 
-  patch<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  patch<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('PATCH', handler);
   }
 
-  options<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  options<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('OPTIONS', handler);
   }
 
-  connect<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  connect<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('CONNECT', handler);
   }
 
-  delete<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  delete<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('DELETE', handler);
   }
 
-  trace<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  trace<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('TRACE', handler);
   }
 
-  post<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  post<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('POST', handler);
   }
 
-  put<T = unknown>(handler: NextApiHandler<T>): RouterBuilder {
+  put<T = unknown, M extends TypedObject = TypedObject>(
+    handler: NextApiHandler<T, M>
+  ): RouterBuilder {
     return this.add('PUT', handler);
   }
 
-  use<T extends Record<string, unknown> = Record<string, unknown>>(
+  use<T extends TypedObject = TypedObject>(
     handler: NextApiHandler<T>
   ): RouterBuilder {
     this.middlewareQueue.push(handler);
     return this;
   }
 
-  inject<T extends Record<string, unknown> = Record<string, unknown>>(
+  inject<T extends TypedObject = TypedObject>(
     handler: NextApiHandler<T>
   ): RouterBuilder {
     this.middlewareList.push(handler);
@@ -202,9 +216,9 @@ export class RouterBuilder {
     );
   }
 
-  private add<T = unknown>(
+  private add<T = unknown, M extends TypedObject = TypedObject>(
     method: string,
-    handler: NextApiHandler<T>
+    handler: NextApiHandler<T, M>
   ): RouterBuilder {
     this.route[method] = handler;
     return this;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix: fix incorrect type declaration of `NextApiRequestWithMiddleware`

- **What is the current behavior?** (You can also link to an open issue here)

when using `router.use`, it will not allow to inject middleware type definition

- **What is the new behavior (if this is a feature change)?**

e.g. can use the following (optional)

```ts
type User = {
  name: string
}
router.use<User>(req => ({name: "USER"}))
router.get<string, User>(req => req.middlware.name) // first type declares the expected returned value
```

- **Other information**:
