### PR TITLE
Fix compatibility caused by type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.2.0](https://github.com/Howard86/next-api-handler/compare/v0.1.0...v0.2.0) (2022-01-01)
+
+
+### ⚠ BREAKING CHANGES
+
+* **type:** update type definition to fix compatibility
+
+### Bug Fixes
+
+* example/package.json & example/yarn.lock to reduce vulnerabilities ([50ea312](https://github.com/Howard86/next-api-handler/commit/50ea31207f997efbba2084d614b3377116978763))
+* **type:** update type definition to fix compatibility ([7a8cfc0](https://github.com/Howard86/next-api-handler/commit/7a8cfc0ecff2cd18780a75cb0f97311a397f2e3d))
+
 ## [0.1.0](https://github.com/Howard86/next-api-handler/compare/v0.0.7...v0.1.0) (2021-12-02)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-api-handler",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "lightweight nextjs api handler wrapper, portable & configurable for serverless environment",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "release": "standard-version",
     "reset-hard": "git clean -dfx && git reset --hard && yarn",
-    "prepare-release": "run-s reset-hard test cov:check doc:html release doc:publish"
+    "prepare-release": "run-s reset-hard test cov:check doc:html doc:publish"
   },
   "engines": {
     "node": ">=14"

--- a/src/lib/error-handler.spec.ts
+++ b/src/lib/error-handler.spec.ts
@@ -1,13 +1,12 @@
 import test from 'ava';
-import type { NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 import sinon, { SinonSpy } from 'sinon';
 
 import { makeErrorHandler } from './error-handler';
 import { HttpException } from './http-exceptions';
 import { ErrorApiResponse } from './router';
-import { NextApiRequestWithMiddleware } from './router';
 
-const req = {} as unknown as NextApiRequestWithMiddleware;
+const req = {} as unknown as NextApiRequest;
 const res = {
   status(_statusCode: number) {
     return this;

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -1,10 +1,10 @@
-import type { NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { HttpException } from './http-exceptions';
-import type { ErrorApiResponse, NextApiRequestWithMiddleware } from './router';
+import type { ErrorApiResponse } from './router';
 
 export type ApiErrorHandler = (
-  req: NextApiRequestWithMiddleware,
+  req: NextApiRequest,
   res: NextApiResponse<ErrorApiResponse>,
   error: Error
 ) => void;

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,0 +1,9 @@
+declare module 'next' {
+  interface NextApiRequest<
+    T extends Record<string, unknown> = Record<string, unknown>
+  > {
+    middleware: T;
+  }
+}
+
+export {};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix: this package introduced a lot of custom types that conflicted with next.js built-in type

- **What is the current behavior?** (You can also link to an open issue here)

lots of custom type (type alias & interface)

- **What is the new behavior (if this is a feature change)?**

extend next.js built-in interface and use `any` for internal type-checking (should not affect library users)
also removed lots of existed type

- **Other information**:

This PR will introduce breaking changes on `next-api-handler` type definition, make sure to run type check after upgrade (e.g. tsc --noEmit)

