### PR TITLE
Fix missing req type declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.1](https://github.com/Howard86/next-api-handler/compare/v0.2.0...v0.2.1) (2022-01-01)
+
+
+### Bug Fixes
+
+* **type:** remove nextjs type redeclaration with NextApiRequestWithMiddleware ([f4f922a](https://github.com/Howard86/next-api-handler/commit/f4f922abace90f986d817d24be38e358c61b4cfe))
+
 ## [0.2.0](https://github.com/Howard86/next-api-handler/compare/v0.1.0...v0.2.0) (2022-01-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-api-handler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "lightweight nextjs api handler wrapper, portable & configurable for serverless environment",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/types/next.d.ts
+++ b/src/types/next.d.ts
@@ -1,9 +1,0 @@
-declare module 'next' {
-  interface NextApiRequest<
-    T extends Record<string, unknown> = Record<string, unknown>
-  > {
-    middleware: T;
-  }
-}
-
-export {};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This will add `NextApiReqeustWithMiddleware` type back to v0.2.0 

- **What is the current behavior?** (You can also link to an open issue here)

We meet an expected `any` type in following scenario

```typescript
const router = new RouterBuilder()

// here req will be 'any' instead of 'NextApiRequest'
router.get(req => {
  ...
})
```

- **What is the new behavior (if this is a feature change)?**

```typescript
const router = new RouterBuilder()

// here req will be 'NextApiRequestWithMiddleware'
router.get(req => {
  ...
})
```

- **Other information**:
