### PR TITLE
[Bugfix] fix sending response when header is sent

### DIFF
--- a/src/lib/router-builder.spec.ts
+++ b/src/lib/router-builder.spec.ts
@@ -31,6 +31,7 @@ const res = {
   json(_data: unknown) {
     return;
   },
+  headerSent: false,
 } as unknown as NextApiResponse;
 
 let spiedJson: SinonSpy<[data: unknown], void>;
@@ -120,6 +121,30 @@ test.serial(
         );
         t.true(spiedStatus.calledWith(200));
         t.true(
+          spiedJson.calledWith({
+            success: true,
+            data: TEXT,
+          } as SuccessApiResponse<string>)
+        );
+      })
+    );
+  }
+);
+
+test.serial(
+  'should not return values when header is already sent',
+  async (t) => {
+    await Promise.all(
+      ROUTING_METHODS.map(async (method) => {
+        const TEXT = `${method.toUpperCase()}_API_RESPONSE`;
+        router[method]((_req) => TEXT);
+        const handler = router.build();
+        await handler(
+          { method: method.toUpperCase() } as NextApiRequestWithMiddleware,
+          { ...res, headersSent: true } as NextApiResponse
+        );
+        t.false(spiedStatus.calledWith(200));
+        t.false(
           spiedJson.calledWith({
             success: true,
             data: TEXT,

--- a/src/lib/router-builder.ts
+++ b/src/lib/router-builder.ts
@@ -209,10 +209,13 @@ export class RouterBuilder {
         const data = await Promise.resolve(
           handler(req as NextApiRequestWithMiddleware, res)
         );
-        return res.status(200).json({
-          success: true,
-          data,
-        });
+
+        if (!res.headersSent) {
+          res.status(200).json({
+            success: true,
+            data,
+          });
+        }
       } catch (error) {
         this.routerOptions.error(req, res, error as Error);
       }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

it will throw error if header is sent, e.g. we use `res.direct` in the handler

- **What is the new behavior (if this is a feature change)?**

it shall not throw error as we prevent calling `res.send`

- **Other information**:
