### PR TITLE
[Feature] add route specific middleware

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-export * from './lib/router-builder';
-export * from './lib/http-exceptions';
+export * from './lib';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_MIDDLEWARE_ROUTER_METHOD = 'ALL' as const;

--- a/src/lib/error-handler.spec.ts
+++ b/src/lib/error-handler.spec.ts
@@ -4,7 +4,7 @@ import sinon, { SinonSpy } from 'sinon';
 
 import { makeErrorHandler } from './error-handler';
 import { HttpException } from './http-exceptions';
-import { ErrorApiResponse } from './router-builder';
+import { ErrorApiResponse } from './type';
 
 const req = {} as unknown as NextApiRequest;
 const res = {

--- a/src/lib/error-handler.ts
+++ b/src/lib/error-handler.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 import { HttpException } from './http-exceptions';
-import type { ErrorApiResponse } from './router-builder';
+import { ErrorApiResponse } from './type';
 
 export type ApiErrorHandler = (
   req: NextApiRequest,

--- a/src/lib/express-like-router.ts
+++ b/src/lib/express-like-router.ts
@@ -1,0 +1,82 @@
+import type { NextApiHandler } from 'next';
+
+import { DEFAULT_MIDDLEWARE_ROUTER_METHOD } from './constants';
+import {
+  AddMiddleware,
+  InternalMiddlewareMap,
+  MiddlewareRouterMethod,
+  NextApiHandlerWithMiddleware,
+  RouterMethod,
+  TypedObject,
+} from './type';
+
+export abstract class ExpressLikeRouter {
+  protected readonly middlewareParallelListMap: InternalMiddlewareMap = {};
+  protected readonly middlewareQueueMap: InternalMiddlewareMap = {};
+
+  protected readonly routeHandlerMap: Partial<
+    Record<
+      RouterMethod,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      NextApiHandlerWithMiddleware<unknown, any>
+    >
+  > = {};
+
+  readonly use = this.addMiddleware(this.middlewareQueueMap);
+  readonly inject = this.addMiddleware(this.middlewareParallelListMap);
+
+  readonly get = this.addRouterMethod('GET');
+  readonly head = this.addRouterMethod('HEAD');
+  readonly patch = this.addRouterMethod('PATCH');
+  readonly options = this.addRouterMethod('OPTIONS');
+  readonly connect = this.addRouterMethod('CONNECT');
+  readonly delete = this.addRouterMethod('DELETE');
+  readonly trace = this.addRouterMethod('TRACE');
+  readonly post = this.addRouterMethod('POST');
+  readonly put = this.addRouterMethod('PUT');
+
+  public abstract build(): NextApiHandler;
+
+  private addMiddleware(middlewareMap: InternalMiddlewareMap) {
+    return (<
+      T extends TypedObject = TypedObject,
+      M extends TypedObject = TypedObject
+    >(
+      methodOrHandler:
+        | MiddlewareRouterMethod
+        | NextApiHandlerWithMiddleware<T, M>,
+      handler?: NextApiHandlerWithMiddleware<T, M>
+    ): ExpressLikeRouter => {
+      const isSingleParam = typeof methodOrHandler !== 'string';
+
+      this.addOrSetPartialArrayMap(
+        middlewareMap,
+        isSingleParam ? DEFAULT_MIDDLEWARE_ROUTER_METHOD : methodOrHandler,
+        isSingleParam ? methodOrHandler : handler
+      );
+
+      return this;
+    }) as AddMiddleware<ExpressLikeRouter>;
+  }
+
+  private addOrSetPartialArrayMap<K extends string, V>(
+    partialMap: Partial<Record<K, V[]>>,
+    mapKey: K,
+    mapValue: V
+  ) {
+    if (Array.isArray(partialMap[mapKey])) {
+      partialMap[mapKey]!.push(mapValue);
+    } else {
+      partialMap[mapKey] = [mapValue];
+    }
+  }
+
+  private addRouterMethod(method: RouterMethod) {
+    return <T, M extends TypedObject = TypedObject>(
+      handler: NextApiHandlerWithMiddleware<T, M>
+    ): ExpressLikeRouter => {
+      this.routeHandlerMap[method] = handler;
+      return this;
+    };
+  }
+}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,4 @@
+export * from './router-builder';
+export * from './http-exceptions';
+export * from './type';
+export * from './constants';

--- a/src/lib/router-builder.spec.ts
+++ b/src/lib/router-builder.spec.ts
@@ -2,12 +2,12 @@ import test from 'ava';
 import type { NextApiResponse } from 'next';
 import sinon, { SinonSpy } from 'sinon';
 
+import { RouterBuilder } from './router-builder';
 import {
   ErrorApiResponse,
   NextApiRequestWithMiddleware,
-  RouterBuilder,
   SuccessApiResponse,
-} from './router-builder';
+} from './type';
 
 const ROUTING_METHODS = [
   'get',

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { DEFAULT_MIDDLEWARE_ROUTER_METHOD } from './constants';
+import { ApiErrorHandler } from './error-handler';
+
+/**
+ *  an utility type to shorten writing Record<string, T = unknown>
+ */
+export type TypedObject<T = unknown> = Record<string, T>;
+
+/**
+ *  a standard next.js api handler but with req.middleware available
+ *  see [official doc](https://nextjs.org/docs/api-routes/introduction) for more details
+ */
+export type NextApiHandlerWithMiddleware<
+  T = unknown,
+  M extends TypedObject = TypedObject
+> = (
+  req: NextApiRequestWithMiddleware<M>,
+  res: NextApiResponse
+) => T | Promise<T>;
+
+/**
+ *  a standard next.js api request but with req.middleware available
+ */
+export interface NextApiRequestWithMiddleware<
+  M extends TypedObject = TypedObject
+> extends NextApiRequest {
+  middleware: M;
+}
+
+/**
+ *  all api response combines success response & error response
+ */
+export type ApiResponse<T = unknown> = SuccessApiResponse<T> | ErrorApiResponse;
+
+/**
+ *  api response that has http status code 2xx with data
+ */
+export type SuccessApiResponse<T> = { success: true; data: T };
+
+/**
+ *  api response that has http status code 4xx or 5xx with error message
+ */
+export type ErrorApiResponse = { success: false; message: string };
+
+/**
+ * RouterBuilder options
+ */
+export type RouterBuilderOptions = Partial<{
+  error: ApiErrorHandler;
+  showMessage: boolean;
+}>;
+
+export type InternalMiddlewareMap = Partial<
+  Record<
+    MiddlewareRouterMethod,
+    NextApiHandlerWithMiddleware<
+      TypedObject,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      any
+    >[]
+  >
+>;
+
+export type RouterMethod =
+  | 'GET'
+  | 'HEAD'
+  | 'PATCH'
+  | 'OPTIONS'
+  | 'CONNECT'
+  | 'DELETE'
+  | 'TRACE'
+  | 'POST'
+  | 'PUT';
+
+export type MiddlewareRouterMethod =
+  | typeof DEFAULT_MIDDLEWARE_ROUTER_METHOD
+  | RouterMethod;

--- a/src/lib/type.ts
+++ b/src/lib/type.ts
@@ -77,3 +77,13 @@ export type RouterMethod =
 export type MiddlewareRouterMethod =
   | typeof DEFAULT_MIDDLEWARE_ROUTER_METHOD
   | RouterMethod;
+
+export type AddMiddleware<R> = {
+  <T extends TypedObject = TypedObject, M extends TypedObject = TypedObject>(
+    method: MiddlewareRouterMethod,
+    handler: NextApiHandlerWithMiddleware<T, M>
+  ): R;
+  <T extends TypedObject = TypedObject, M extends TypedObject = TypedObject>(
+    handler: NextApiHandlerWithMiddleware<T, M>
+  ): R;
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

- **What is the current behavior?** (You can also link to an open issue here)

Currently, we have middleware that can only be injected for all RESTful api methods (#32) like following  

```ts
import {
  NotFoundException,
  RouterBuilder,
  UnauthorizedException,
} from 'next-api-handler';

import {
  getDataByEmail,
  getEmailFromCookie,
  updateData,
} from '@/server/service';

type CookieMiddlewareResponse = {
  email: string;
};

type UserMiddlewareResponse = {
  id: string;
  name: string;
};

type CombinedMiddlewareResponse = CookieMiddlewareResponse &
  UserMiddlewareResponse;

const router = new RouterBuilder({ showMessage: true });

/**
 *  here router.use<T, M> where
 *  - T: the response type that a middleware emits
 *  - M: the middleware type previously injected and used (optional)
 */
// router.user<T,M> where
router.use<CookieMiddlewareResponse>((req) => {
  const email = getEmailFromCookie(req.cookies['TEST_COOKIE']);

  if (!email) {
    throw new UnauthorizedException();
  }

  return { email };
});

router.use<UserMiddlewareResponse, CookieMiddlewareResponse>(async (req) => {
  const data = await getDataByEmail(req.middleware.email);

  if (!data) {
    throw new NotFoundException();
  }

  return data;
});

router.get<CombinedMiddlewareResponse, CombinedMiddlewareResponse>(
  (req) => req.middleware
);

router.put<CombinedMiddlewareResponse, CombinedMiddlewareResponse>(
  async (req) => {
    const name = req.body?.name as string;
    await updateData(req.middleware.email, name);
    return { ...req.middleware, name };
  }
);

export default router.build();

```

- **What is the new behavior (if this is a feature change)?**

Now we can utilise a route specific method on `router.use` or `router.inject`

```ts
router.use<CookieMiddlewareResponse>('GET', (req) => {
  const email = getEmailFromCookie(req.cookies['TEST_COOKIE']);

  if (!email) {
    throw new UnauthorizedException();
  }

  return { email };
});
```

and 

```ts
router.use<CookieMiddlewareResponse>((req) => {
  const email = getEmailFromCookie(req.cookies['TEST_COOKIE']);

  if (!email) {
    throw new UnauthorizedException();
  }

  return { email };
});
```

is equivalent to 

```ts
router.use<CookieMiddlewareResponse>('ALL', (req) => {
  const email = getEmailFromCookie(req.cookies['TEST_COOKIE']);

  if (!email) {
    throw new UnauthorizedException();
  }

  return { email };
});
```

- **Other information**:

This new feature doesn't introduce breaking changes of current api thanks to TypeScript method overloading
