### PR TITLE
fix: fix incorrect nextjs peer deps version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-api-handler",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "lightweight nextjs api handler wrapper, portable & configurable for serverless environment",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -115,6 +115,6 @@
     ]
   },
   "peerDependencies": {
-    "next": "^12"
+    "next": ">=9"
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix incorrect nextjs peer deps version

- **What is the current behavior?** (You can also link to an open issue here)

when installing `next-api-handler` for `next@13`, it will show a warning of incorrect peer dependencies

- **What is the new behavior (if this is a feature change)?**

it will not show any warning for `next` version greater or equal than 9, i.e. `>=9`

- **Other information**:
