### PR TITLE
fix: fix incorrect next peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,6 @@
     ]
   },
   "peerDependencies": {
-    "next": ">=9"
+    "next": ">= 9 < 14"
   }
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

When install `next-api-handler@0.4.2`, it will show incorrect dependencies for `next@12`

- **What is the new behavior (if this is a feature change)?**

Should not show the peer deps warning

- **Other information**:
