### PR TITLE
Bugfix/add console to error handler

### DIFF
--- a/apps/example/pages/index.tsx
+++ b/apps/example/pages/index.tsx
@@ -24,11 +24,9 @@ export default function Home() {
         </p>
 
         <div className={styles.grid}>
-          <Link href="/about">
-            <a className={styles.card}>
-              <h2>About Page &rarr;</h2>
-              <p>Cypress will test if this link is working.</p>
-            </a>
+          <Link className={styles.card} href="/about">
+            <h2>About Page &rarr;</h2>
+            <p>Cypress will test if this link is working.</p>
           </Link>
 
           <a href="https://nextjs.org/docs" className={styles.card}>

--- a/packages/next-api-handler/src/lib/router-builder.ts
+++ b/packages/next-api-handler/src/lib/router-builder.ts
@@ -62,11 +62,7 @@ export class RouterBuilder extends ExpressLikeRouter {
       const initiatedTime = Date.now();
       const routerMethod = (req.method || 'GET') as RouterMethod;
 
-      this.getLogFormattedMessage(
-        routerMethod,
-        req.url,
-        HandlerLogType.Initiate
-      );
+      this.logHandler(HandlerLogType.Initiate, routerMethod, req.url);
 
       try {
         const handler = this.routeHandlerMap[routerMethod];

--- a/packages/next-api-handler/src/tests/router-builder.spec.ts
+++ b/packages/next-api-handler/src/tests/router-builder.spec.ts
@@ -91,6 +91,26 @@ describe('RouterBuilder', () => {
         },
       });
     });
+
+    it('should prevent sending response twice', async () => {
+      router.get((_req, res) => {
+        res.status(200).json({ message: 'TEST_MESSAGE_SENT' });
+
+        return 'TEST_MESSAGE_UNSENT';
+      });
+
+      await testApiHandler({
+        handler,
+        test: async ({ fetch }) => {
+          const res = await fetch();
+
+          expect(res.status).toBe(200);
+          await expect(res.json()).resolves.toStrictEqual({
+            message: 'TEST_MESSAGE_SENT',
+          });
+        },
+      });
+    });
   });
 
   describe('custom handler', () => {

--- a/packages/next-api-handler/tsup.config.ts
+++ b/packages/next-api-handler/tsup.config.ts
@@ -5,9 +5,9 @@ export default defineConfig((options) => ({
   format: ['cjs', 'esm'],
   splitting: true,
   treeshake: true,
-  sourcemap: true,
-  dts: true,
-  clean: true,
+  sourcemap: !options.watch,
+  dts: !options.watch,
+  clean: !options.watch,
   env: {
     NODE_ENV: options.watch ? 'development' : 'production',
   },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix -> missing logging error when handling errors

- **What is the current behavior?** (You can also link to an open issue here)

  When there's an error sent to next-api-handler, it only shows caught errors without further debugging info

- **What is the new behavior (if this is a feature change)?**

  - Refactor log message from a centralised private `logHandler` method and control logging level and message
  - Add error.trace for non-HttpException errors

- **Other information**:
